### PR TITLE
Get authorization resource with Launchpad client.

### DIFF
--- a/lib/bcx.rb
+++ b/lib/bcx.rb
@@ -15,11 +15,16 @@ module Bcx
     autoload :Project, 'bcx/resources/project'
     autoload :Person, 'bcx/resources/person'
     autoload :Access, 'bcx/resources/access'
+    autoload :Authorization, 'bcx/resources/authorization'
   end
 
   module Client
     autoload :HTTP, 'bcx/client/http'
     autoload :OAuth, 'bcx/client/oauth'
+  end
+
+  module Launchpad
+    autoload :OAuth, 'bcx/launchpad/oauth'
   end
 
   class << self

--- a/lib/bcx/client/oauth.rb
+++ b/lib/bcx/client/oauth.rb
@@ -21,7 +21,7 @@ module Bcx
       resource :people, class_name: 'Bcx::Resources::Person'
 
       def initialize(options = {})
-        @account = Bcx.configuration.account
+        @account = options[:account] || Bcx.configuration.account
         @api_version = Bcx.configuration.api_version
 
         options[:site] = "https://basecamp.com/#{@account}/api/#{@api_version}"

--- a/lib/bcx/launchpad/oauth.rb
+++ b/lib/bcx/launchpad/oauth.rb
@@ -1,0 +1,22 @@
+module Bcx
+  module Launchpad
+    class OAuth < Rapidash::Client
+      method :oauth
+
+      extension :json
+      encode_request_with :json
+
+      raise_errors
+
+      resource :authorization, class_name: "Bcx::Resources::Authorization"
+
+      def initialize(options = {})
+        options[:site]   ||= "https://launchpad.37signals.com"
+        options[:uid]    ||= options[:client_id]
+        options[:secret] ||= options[:client_secret]
+
+        super(options)
+      end
+    end
+  end
+end

--- a/lib/bcx/resources/authorization.rb
+++ b/lib/bcx/resources/authorization.rb
@@ -1,0 +1,16 @@
+module Bcx
+  module Resources
+
+    # Bcx::Resources::Authorization
+    # Provides access to the authorization resource
+    #
+    # Fetch authorization
+    # GET /authorization.json
+    #
+    #   launchpad.authorization!
+    #
+    class Authorization < Rapidash::Base
+      url :authorization
+    end
+  end
+end

--- a/spec/bcx/authorization_spec.rb
+++ b/spec/bcx/authorization_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Bcx::Resources::Authorization, :vcr do
+  let(:launchpad) { Bcx::Launchpad::OAuth.new(client_id: '748cc9c949af86f2e3fb35564f7e209b1d2c27d2', client_secret: '7fba79ec3bf1eb9e278098031414e5a3a41ec842', access_token: 'BAhbByIBsHsiZXhwaXJlc19hdCI6IjIwMTMtMDktMTNUMTI6NDk6MzBaIiwidXNlcl9pZHMiOlsxNzE3NDMwNV0sImNsaWVudF9pZCI6Ijc0OGNjOWM5NDlhZjg2ZjJlM2ZiMzU1NjRmN2UyMDliMWQyYzI3ZDIiLCJ2ZXJzaW9uIjoxLCJhcGlfZGVhZGJvbHQiOiJmZmE1OTgzMzQ3YTY2MWExM2Y1YWE3YTM0ODVhYzk4YiJ9dToJVGltZQ2sYRzA05PlxQ==--e995b8e9cb3cc37b7f4f90d967bb23d889145384') }
+
+  describe "GET /authorization" do
+    let(:authorization) { launchpad.authorization! }
+
+    it "first account should have the correct id" do
+      expect(authorization.accounts.first.id).to eq 2274488
+    end
+  end
+end

--- a/spec/bcx/launchpad_spec.rb
+++ b/spec/bcx/launchpad_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Bcx::Launchpad do
+  context "oauth" do
+    let(:launchpad) { Bcx::Launchpad::OAuth.new(client_id: '748cc9c949af86f2e3fb35564f7e209b1d2c27d2', client_secret: '7fba79ec3bf1eb9e278098031414e5a3a41ec842', access_token: 'BAhbByIBsHsiZXhwaXJlc19hdCI6IjIwMTMtMDktMTNUMTI6NDk6MzBaIiwidXNlcl9pZHMiOlsxNzE3NDMwNV0sImNsaWVudF9pZCI6Ijc0OGNjOWM5NDlhZjg2ZjJlM2ZiMzU1NjRmN2UyMDliMWQyYzI3ZDIiLCJ2ZXJzaW9uIjoxLCJhcGlfZGVhZGJvbHQiOiJmZmE1OTgzMzQ3YTY2MWExM2Y1YWE3YTM0ODVhYzk4YiJ9dToJVGltZQ2sYRzA05PlxQ==--e995b8e9cb3cc37b7f4f90d967bb23d889145384') }
+
+    it "should assign credentials" do
+      expect(launchpad.uid).to eq '748cc9c949af86f2e3fb35564f7e209b1d2c27d2'
+      expect(launchpad.secret).to eq '7fba79ec3bf1eb9e278098031414e5a3a41ec842'
+    end
+
+    it "should provide an access token" do
+      expect(launchpad.access_token).not_to be_nil
+    end
+  end
+end

--- a/spec/cassettes/Bcx_Resources_Authorization/GET_/authorization/first_account_should_have_the_correct_id.yml
+++ b/spec/cassettes/Bcx_Resources_Authorization/GET_/authorization/first_account_should_have_the_correct_id.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://launchpad.37signals.com/authorization.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.8.8
+      content-type:
+      - application/json
+      Authorization:
+      - Bearer BAhbByIBsHsiZXhwaXJlc19hdCI6IjIwMTMtMDktMTNUMTI6NDk6MzBaIiwidXNlcl9pZHMiOlsxNzE3NDMwNV0sImNsaWVudF9pZCI6Ijc0OGNjOWM5NDlhZjg2ZjJlM2ZiMzU1NjRmN2UyMDliMWQyYzI3ZDIiLCJ2ZXJzaW9uIjoxLCJhcGlfZGVhZGJvbHQiOiJmZmE1OTgzMzQ3YTY2MWExM2Y1YWE3YTM0ODVhYzk4YiJ9dToJVGltZQ2sYRzA05PlxQ==--e995b8e9cb3cc37b7f4f90d967bb23d889145384
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Fri, 30 Aug 2013 12:54:58 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      etag:
+      - ! '"08fb7932a74cfd43967d40c6b26b68d4"'
+      x-frame-options:
+      - SAMEORIGIN
+      x-ua-compatible:
+      - IE=Edge,chrome=1
+      x-runtime:
+      - '0.007646'
+      x-request-id:
+      - 4553850ce04a7ecfe50aeb802b895220
+      cache-control:
+      - max-age=0, private, must-revalidate
+      strict-transport-security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ! '{"accounts":[{"name":"Paul Springett''s Basecamp","href":"https://basecamp.com/2274488/api/v1","id":2274488,"product":"bcx"}],"identity":{"id":6967737,"last_name":"Springett","email_address":"paul@springett.me","first_name":"Paul"},"expires_at":"2013-09-13T12:49:30Z"}'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2013 12:55:00 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
This pull request adds a Launchpad client which hits the endpoint `https://launchpad.37signals.com/authorization.json`.

You would use the Launchpad client when you need to know which accounts a user has access to. It also provides the expiration time of the token in use.

Here's an example of the JSON returned:

``` json
{
  "expires_at": "2012-03-22T16:56:48-05:00",
  "identity": {
    "id": 9999999,
    "name": "Jason Fried",
    "email_address": "jason@37signals.com",
  },
  "accounts": [
    {
      "product": "bcx",
      "id": 88888888,
      "name": "Wayne Enterprises, Ltd.",
      "href": "https://basecamp.com/88888888/api/v1",
    },
    {
      "product": "bcx",
      "id": 77777777,
      "name": "Veidt, Inc",
      "href": "https://basecamp.com/77777777/api/v1",
    },
    {
      "product": "campfire",
      "id": 44444444,
      "name": "Acme Shipping Co.",
      "href": "https://acme4444444.campfirenow.com"
    }
  ]
}
```
