### PR TITLE
Update: Require Rapidash 0.3.0

### DIFF
--- a/bcx.gemspec
+++ b/bcx.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Bcx::VERSION
 
-  gem.add_runtime_dependency 'rapidash', '0.3.0.beta2'
+  gem.add_runtime_dependency 'rapidash', '~>0.3.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Update to use the non-beta version of Rapidash.
