### PR TITLE
Creating configuration block on the fly in case user does not call configure

### DIFF
--- a/lib/bcx.rb
+++ b/lib/bcx.rb
@@ -29,12 +29,17 @@ module Bcx
   end
 
   class << self
-    attr_accessor :configuration
+    attr_writer :configuration
+  end
+
+  # Create configuration block in case the user does not call configure
+  def self.configuration
+    self.class.instance_variable_set('@configuration',Configuration.new) if self.class.instance_variable_get('@configuration').nil?
+    self.class.instance_variable_get('@configuration')
   end
 
   # Expose configuration block
   def self.configure
-    self.configuration ||= Configuration.new
     yield(configuration)
   end
 end


### PR DESCRIPTION
When using the OAth client, there is actually no need to call Bcx.configure (as the account is likely passed as an option of the client).  If Bcx.configure is not called, then OAuth.client.new crashes with api_version undefined. This fixes it by ensuring Bcx.configuration.new is always called. 