### PR TITLE
Providing tech identifiable information to Basecamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ $ bundle install
 
 ### Usage
 
-Configure Bcx for your Basecamp account
+Configure Bcx for your Basecamp account. Basecamp requests that you provide contact information for your app through the user_agent string, for eventual technical issues.
 
 ```ruby
 Bcx.configure do |config|
   config.account = '1234567890'
+  config.user_agent = 'My great app name. https://app.com/contact_us.rb, contact: me@me.com'
 end
 ```
 
@@ -82,7 +83,7 @@ client = Bcx::Client::OAuth.new(client_id: '1234567890', client_secret: '831994c
 
 You can get a `client_id` and `client_secret` from https://integrate.37signals.com/
 
-You can also pass an `:account` option to the OAuth client (allowing multiple clients in your app).
+You can also pass an `:account` option to the OAuth client (allowing multiple clients in your app), in which case do you not need to specify an account in the config block.
 
 ```ruby
 client = Bcx::Client::OAuth.new(account: 99999999, ...)

--- a/bcx.gemspec
+++ b/bcx.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Bcx::VERSION
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'rapidash', '~> 0.3.0'
+  gem.add_runtime_dependency 'rapidash', '~> 0.4.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'

--- a/lib/bcx/client/http.rb
+++ b/lib/bcx/client/http.rb
@@ -24,6 +24,12 @@ module Bcx
       def initialize(options = {})
         @account = Bcx.configuration.account
         @api_version = Bcx.configuration.api_version
+        @user_agent = options[:user_agent] || Bcx.configuration.user_agent
+        if @user_agent
+          options[:request_default_options] ||= {}
+          options[:request_default_options][:header] ||= {}
+          options[:request_default_options][:header][:user_agent] ||= @user_agent
+        end
 
         self.class.site("https://basecamp.com/#{@account}/api/#{@api_version}/")
 

--- a/lib/bcx/client/oauth.rb
+++ b/lib/bcx/client/oauth.rb
@@ -23,10 +23,17 @@ module Bcx
       def initialize(options = {})
         @account = options[:account] || Bcx.configuration.account
         @api_version = Bcx.configuration.api_version
+        @user_agent = options[:user_agent] || Bcx.configuration.user_agent
 
         options[:site] = "https://basecamp.com/#{@account}/api/#{@api_version}"
         options[:uid] ||= options[:client_id]
         options[:secret] ||= options[:client_secret]
+
+        if @user_agent
+          options[:request_default_options] ||= {}
+          options[:request_default_options][:header] ||= {}
+          options[:request_default_options][:header][:user_agent] ||= @user_agent
+        end
 
         super(options)
       end

--- a/lib/bcx/configuration.rb
+++ b/lib/bcx/configuration.rb
@@ -10,7 +10,7 @@
 #
 module Bcx
   class Configuration
-    attr_accessor :account, :api_version
+    attr_accessor :account, :api_version, :user_agent
 
     def initialize
       @api_version = 'v1'

--- a/spec/bcx/access_spec.rb
+++ b/spec/bcx/access_spec.rb
@@ -19,7 +19,7 @@ describe Bcx::Resources::Access, :vcr do
     it "should grant access" do
       client.projects(2951531).accesses.create!(email_addresses: ["hopper.derek@gmail.com"])
       accesses = client.projects(2951531).accesses!
-      accesses.detect { |access| access.id == 4996562 }.should be_present
+      expect(accesses.detect { |access| access.id == 4996562 }).to be_present
     end
   end
 
@@ -27,7 +27,7 @@ describe Bcx::Resources::Access, :vcr do
     it "should revoke access" do
       client.projects(2951531).accesses(4996562).delete!
       accesses = client.projects(2951531).accesses!
-      accesses.detect { |access| access.id == 4996562 }.should_not be_present
+      expect(accesses.detect { |access| access.id == 4996562 }).not_to be_present
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,4 @@ RSpec.configure do |config|
     Bcx.configure { |config| config.account = '2274488' }
   end
 
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end


### PR DESCRIPTION
Basecamp requests to have contact information provided in the User-agent string.
This changes adds the possibility of configuring the User-agent string provided in the http requests made to Basecamp. The supporting infrastructure changes have already been included in rapidash 0.4

Also, fixing Rspec depreciation warnings. 