### PR TITLE
Handling errors when they are strings as opposed to contained in an array

### DIFF
--- a/lib/bcx/response_error.rb
+++ b/lib/bcx/response_error.rb
@@ -27,7 +27,11 @@ module Bcx
       messages = []
 
       body.each_pair do |attribute, msgs|
-        msgs.each { |msg| messages.push "#{attribute} #{msg}" }
+        if msgs.respond_to? :each
+          msgs.each { |msg| messages.push "#{attribute} #{msg}" }
+        else
+          messages.push "#{attribute} #{msgs.to_s}"
+        end
       end
 
       messages.join(', ')

--- a/spec/bcx/client_spec.rb
+++ b/spec/bcx/client_spec.rb
@@ -33,13 +33,20 @@ describe Bcx::Client do
 
   describe "error handling", :vcr do
     let(:client) { Bcx::Client::HTTP.new(login: 'bcx-test-user', password: 'secret') }
-
-    it "should raise exception" do
+    it "should raise exception_with_array_error" do
       expect { client.projects.create!(name: '') }.to raise_error { |response|
         expect(response).to be_a Bcx::ResponseError
         expect(response.status).to eq 422
         expect(response.errors).to include("name can't be blank")
       }
+    end
+
+    it "should raise exception_with_string_error" do
+      expect { client.projects.create!(name: '') }.to raise_error { |response|
+                                                        expect(response).to be_a Bcx::ResponseError
+                                                        expect(response.status).to eq 422
+                                                        expect(response.errors).to include("name can't be blank")
+                                                      }
     end
   end
 end

--- a/spec/cassettes/Bcx_Client/error_handling/should_raise_exception_with_array_error.yml
+++ b/spec/cassettes/Bcx_Client/error_handling/should_raise_exception_with_array_error.yml
@@ -50,7 +50,7 @@ http_interactions:
       - '0.145644'
     body:
       encoding: US-ASCII
-      string: ! '{"name":["can''t be blank"]}'
+      string: ! '{"name":["can''t be blank","can''t be duplicate"]}'
     http_version: 
   recorded_at: Fri, 21 Jun 2013 21:32:47 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Bcx_Client/error_handling/should_raise_exception_with_string_error.yml
+++ b/spec/cassettes/Bcx_Client/error_handling/should_raise_exception_with_string_error.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://basecamp.com/2274488/api/v1/projects.json
+    body:
+      encoding: UTF-8
+      string: ! '{"name":""}'
+    headers:
+      User-Agent:
+      - Faraday v0.8.7
+      Authorization:
+      - Basic YmN4LXRlc3QtdXNlcjpzZWNyZXQ=
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 422
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Fri, 21 Jun 2013 21:32:47 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 422 Unprocessable Entity
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      x-ua-compatible:
+      - chrome=1
+      x-xhr-current-location:
+      - /2274488/api/v1/projects.json
+      x-asset-paths:
+      - ! '{"application.js":"application-eb8afc75ba8fcbb36b8518826dd32bc5.js","application.css":"application-18059b31e3ebdcca82003cfaf2564179.css"}'
+      cache-control:
+      - no-cache
+      x-request-id:
+      - e203c487-d807-41b5-afd6-4f709fcb35e3
+      x-runtime:
+      - '0.145644'
+    body:
+      encoding: US-ASCII
+      string: ! '{"name":"can''t be blank"}'
+    http_version: 
+  recorded_at: Fri, 21 Jun 2013 21:32:47 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
Basecamp sometimes returns errors in a string, as opposed to encapsulated in an array.  As a result, existing code crashes. This patch handles this case more gracefully.
